### PR TITLE
Fix external PCK loading

### DIFF
--- a/core/singletons/utils.gd
+++ b/core/singletons/utils.gd
@@ -30,6 +30,7 @@ func get_files_recursive(path: String, regex: RegEx = null) -> Array:
 	var files = []
 	var dir = DirAccess.open(path)
 	if dir:
+		dir.list_dir_begin()
 		var file := dir.get_next()
 		while file != "":
 			if dir.current_is_dir():
@@ -51,7 +52,7 @@ func get_files_recursive(path: String, regex: RegEx = null) -> Array:
 # PackageManager -------------------------
 # Load Packages from given paths (with order)
 func load_packages(paths: Array) -> void:
-	if OS.has_feature("standalone"):
+	if OS.has_feature("template"):
 		# Load if exported.
 		pckmgr.set_path(paths)
 		pckmgr.load_packages()


### PR DESCRIPTION
The script was looking if the `standalone` feature tag exists, however it was renamed to `template` in Godot 4.0.

As well, the function that deals with external PCK loading misses the `list_dir_begin()` function, required to populate the list, as it returns error 31.

This PR fixes both issues.